### PR TITLE
Get PSS of pid from smaps_rollup file

### DIFF
--- a/lib/get_process_mem.rb
+++ b/lib/get_process_mem.rb
@@ -21,7 +21,9 @@ class GetProcessMem
   RUNS_ON_WINDOWS = Gem.win_platform?
 
   def self.preferred_pss?
-    @preferred_pss ||= false
+    return @preferred_pss unless @preferred_pss.nil?
+
+    @preferred_pss
   end
 
   def self.preferred_pss=(value)

--- a/lib/get_process_mem/version.rb
+++ b/lib/get_process_mem/version.rb
@@ -1,3 +1,3 @@
 class GetProcessMem
-  VERSION = "1.0.0"
+  VERSION = "1.0.0.1"
 end

--- a/test/fixtures/linux-bash-smaps_rollup
+++ b/test/fixtures/linux-bash-smaps_rollup
@@ -1,0 +1,17 @@
+00400000-ffffffffff601000 ---p 00000000 00:00 0                          [rollup]
+Rss:               13048 kB
+Pss:               11563 kB
+Shared_Clean:       1712 kB
+Shared_Dirty:        108 kB
+Private_Clean:      6124 kB
+Private_Dirty:      5104 kB
+Referenced:        12988 kB
+Anonymous:         11420 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:              27432 kB
+SwapPss:           26152 kB
+Locked:                0 kB

--- a/test/get_process_mem_test.rb
+++ b/test/get_process_mem_test.rb
@@ -67,4 +67,10 @@ class GetProcessMemTest < Test::Unit::TestCase
     assert_in_delta 1024.0, @mem.mb(bytes), delta
     assert_in_delta 1.0, @mem.gb(bytes), delta
   end
+
+  def test_linux_smaps_rollup
+    delta = 1
+    bytes = @mem.linux_pss_memory(fixture_path("linux-bash-smaps_rollup"))
+    assert_in_delta BigDecimal("11840512.0"), bytes, delta
+  end
 end


### PR DESCRIPTION
## /proc/$pid/status の VmRSS を使用（デフォルト）

### 起動直後

ps aux によるRSS: 511604 + 499188 + 499188 = 1,509,980 KB

puma worker killer の on_calculation によって RSS による測定
```
INFO -- : Current memory footprint: 1474.73046875 MB
```

### API にアクセスし続けた後、他プロセスでメモリを使って OS に返させた状態

ps aux による RSS: 134708 + 336780 + 171804 = 643,292 KB

on_calculation によって RSS による測定
```
INFO -- : Current memory footprint: 690.90625 MB
```

## /proc/$pid/smaps_rollup の PSS を使用

### 起動直後

ps aux による RSS: 511736 + 503992 + 499260 = 1,514,988 KB

on_calculation によって PSS による測定
```
INFO -- : Current memory footprint: 520.5556640625 MB
```

### API にアクセスし続けた後、他プロセスでメモリを使って OS に返させた状態

ps aux による RSS: 33692 + 341844 + 221904 = 597,440 KB

on_calculation によって PSS による測定
```
INFO -- : Current memory footprint: 534.591796875 MB
```